### PR TITLE
Typedef structs

### DIFF
--- a/bcmpr-bipsw/include/bcmpr.h
+++ b/bcmpr-bipsw/include/bcmpr.h
@@ -10,7 +10,7 @@
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
-struct Params
+typedef struct
 {
     size_t key_len;
     EVP_CIPHER_CTX *hash_ctx;
@@ -18,63 +18,63 @@ struct Params
     BIGNUM *order;
     BN_CTX *ctx;
     const EC_POINT *g;
-};
+} Params;
 
-struct Key
+typedef struct
 {
     BIGNUM **key;
 
     // optional
     BIGNUM *delta;
     EC_POINT **offsets;
-};
+} Key;
 
-struct KeyCache
+typedef struct
 {
     size_t cache_bits;
     BIGNUM **cache;
-};
+} KeyCache;
 
-int setup(struct Params *pp, size_t key_len);
-int key_gen(struct Params *pp, struct Key *msk);
+int setup(Params *pp, size_t key_len);
+int key_gen(Params *pp, Key *msk);
 
 int sender_eval(
-    struct Params *pp,
-    struct KeyCache *msk_cache,
+    Params *pp,
+    KeyCache *msk_cache,
     uint128_t *inputs,
     uint128_t *outputs,
     size_t num_ots);
 
 int receiver_eval(
-    struct Params *pp,
-    struct Key *csk0,
-    struct Key *csk1,
-    struct KeyCache *csk_cache_0,
-    struct KeyCache *csk_cache_1,
+    Params *pp,
+    Key *csk0,
+    Key *csk1,
+    KeyCache *csk_cache_0,
+    KeyCache *csk_cache_1,
     uint8_t *constraint,
     uint128_t *inputs,
     uint128_t *outputs,
     size_t num_ots);
 
 int constrain_key_gen(
-    struct Params *pp,
-    struct Key *msk,
-    struct Key *csk,
+    Params *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint,
     size_t index);
 
 int compute_cache(
-    struct Params *pp,
+    Params *pp,
     BIGNUM **key,
-    struct KeyCache *key_cache,
+    KeyCache *key_cache,
     size_t cache_bits);
 
-void free_master_key(struct Params *pp, struct Key *msk);
-void free_constrained_key(struct Params *pp, struct Key *csk);
-void free_cache(struct Params *pp, struct KeyCache *key_cache);
-void free_public_params(struct Params *pp);
+void free_master_key(Params *pp, Key *msk);
+void free_constrained_key(Params *pp, Key *csk);
+void free_cache(Params *pp, KeyCache *key_cache);
+void free_public_params(Params *pp);
 
-static inline size_t get_curve_point_byte_size(struct Params *pp)
+static inline size_t get_curve_point_byte_size(Params *pp)
 {
     // get byte size of curve point
     size_t point_len = EC_POINT_point2oct(

--- a/bcmpr-bipsw/src/bcmpr.c
+++ b/bcmpr-bipsw/src/bcmpr.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include "params.h"
 
-int setup(struct Params *pp, size_t key_len)
+int setup(Params *pp, size_t key_len)
 {
     pp->key_len = key_len;
     pp->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
@@ -42,7 +42,7 @@ err:
     return 0;
 }
 
-int key_gen(struct Params *pp, struct Key *msk)
+int key_gen(Params *pp, Key *msk)
 {
     msk->key = malloc(sizeof(void *) * pp->key_len);
     msk->delta = BN_new();
@@ -105,9 +105,9 @@ err:
 }
 
 int constrain_key_gen(
-    struct Params *pp,
-    struct Key *msk,
-    struct Key *csk,
+    Params *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint,
     size_t index)
 {
@@ -153,9 +153,9 @@ err:
 }
 
 int compute_cache(
-    struct Params *pp,
+    Params *pp,
     BIGNUM **key,
-    struct KeyCache *key_cache,
+    KeyCache *key_cache,
     size_t cache_bits)
 {
 
@@ -206,8 +206,8 @@ err:
 }
 
 int sender_eval(
-    struct Params *pp,
-    struct KeyCache *msk_cache,
+    Params *pp,
+    KeyCache *msk_cache,
     uint128_t *inputs,
     uint128_t *outputs,
     size_t num_ots)
@@ -317,11 +317,11 @@ err:
 }
 
 int receiver_eval(
-    struct Params *pp,
-    struct Key *csk0,
-    struct Key *csk1,
-    struct KeyCache *csk_cache_0,
-    struct KeyCache *csk_cache_1,
+    Params *pp,
+    Key *csk0,
+    Key *csk1,
+    KeyCache *csk_cache_0,
+    KeyCache *csk_cache_1,
     uint8_t *constraint,
     uint128_t *inputs,
     uint128_t *outputs,
@@ -349,8 +349,8 @@ int receiver_eval(
 
     uint128_t *prf_inputs = malloc(sizeof(uint128_t) * num_ots * point_len_blocks);
 
-    struct Key *csk;
-    struct KeyCache *csk_cache;
+    Key *csk;
+    KeyCache *csk_cache;
 
     size_t input_step = ceil((pp->key_len) / 128);
 
@@ -475,7 +475,7 @@ err:
     return 0;
 }
 
-void free_master_key(struct Params *pp, struct Key *msk)
+void free_master_key(Params *pp, Key *msk)
 {
     for (size_t i = 0; i < pp->key_len; i++)
     {
@@ -493,7 +493,7 @@ void free_master_key(struct Params *pp, struct Key *msk)
     free(msk);
 }
 
-void free_constrained_key(struct Params *pp, struct Key *csk)
+void free_constrained_key(Params *pp, Key *csk)
 {
     for (size_t i = 0; i < pp->key_len; i++)
     {
@@ -506,7 +506,7 @@ void free_constrained_key(struct Params *pp, struct Key *csk)
     free(csk);
 }
 
-void free_cache(struct Params *pp, struct KeyCache *key_cache)
+void free_cache(Params *pp, KeyCache *key_cache)
 {
     size_t cache_size = (pp->key_len / key_cache->cache_bits) * (1 << key_cache->cache_bits);
     for (size_t i = 0; i < cache_size; i++)
@@ -518,7 +518,7 @@ void free_cache(struct Params *pp, struct KeyCache *key_cache)
     free(key_cache);
 }
 
-void free_public_params(struct Params *pp)
+void free_public_params(Params *pp)
 {
     if (pp->curve)
         EC_GROUP_free(pp->curve);

--- a/bcmpr-bipsw/src/test.c
+++ b/bcmpr-bipsw/src/test.c
@@ -31,14 +31,14 @@ double benchmarkOTs()
     // **********************************
     // Generate public parameters
     // **********************************
-    struct Params *pp = (struct Params *)malloc(sizeof(struct Params));
+    Params *pp = (Params *)malloc(sizeof(Params));
     setup(pp, key_len);
 
     // **********************************
     // Generate CPRF keys
     // **********************************
-    struct Key *msk0 = (struct Key *)malloc(sizeof(struct Key));
-    struct Key *msk1 = (struct Key *)malloc(sizeof(struct Key));
+    Key *msk0 = (Key *)malloc(sizeof(Key));
+    Key *msk1 = (Key *)malloc(sizeof(Key));
     if (!key_gen(pp, msk0))
         printf("ERROR: when generating msk0\n");
     if (!key_gen(pp, msk1))
@@ -52,24 +52,24 @@ double benchmarkOTs()
     for (size_t i = 0; i < key_len; i++)
         constraint[i] &= 1;
 
-    struct Key *csk0 = (struct Key *)malloc(sizeof(struct Key));
-    struct Key *csk1 = (struct Key *)malloc(sizeof(struct Key));
+    Key *csk0 = (Key *)malloc(sizeof(Key));
+    Key *csk1 = (Key *)malloc(sizeof(Key));
     constrain_key_gen(pp, msk0, csk0, constraint, 0);
     constrain_key_gen(pp, msk1, csk1, constraint, 1);
 
     // **********************************
     // Compute caches
     // **********************************
-    struct KeyCache *msk0_cache = (struct KeyCache *)malloc(sizeof(struct KeyCache));
-    struct KeyCache *msk1_cache = (struct KeyCache *)malloc(sizeof(struct KeyCache));
+    KeyCache *msk0_cache = (KeyCache *)malloc(sizeof(KeyCache));
+    KeyCache *msk1_cache = (KeyCache *)malloc(sizeof(KeyCache));
     if (!compute_cache(pp, msk0->key, msk0_cache, CACHE_BITS))
         printf("Error ocurred when computing cache with msk0\n");
 
     if (!compute_cache(pp, msk1->key, msk1_cache, CACHE_BITS))
         printf("Error ocurred when computing cache with msk1\n");
 
-    struct KeyCache *csk0_cache = (struct KeyCache *)malloc(sizeof(struct KeyCache));
-    struct KeyCache *csk1_cache = (struct KeyCache *)malloc(sizeof(struct KeyCache));
+    KeyCache *csk0_cache = (KeyCache *)malloc(sizeof(KeyCache));
+    KeyCache *csk1_cache = (KeyCache *)malloc(sizeof(KeyCache));
     compute_cache(pp, csk0->key, csk0_cache, CACHE_BITS);
     compute_cache(pp, csk1->key, csk1_cache, CACHE_BITS);
 

--- a/other/include/other.h
+++ b/other/include/other.h
@@ -10,36 +10,36 @@
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
-struct Params
+typedef struct
 {
     size_t key_len;
     EC_GROUP *curve;
     BIGNUM *order;
     BN_CTX *ctx;
     const EC_POINT *g;
-};
+} Params;
 
-struct Key
+typedef struct
 {
     BIGNUM **key;
 
     // optional
     BIGNUM *delta;
-};
+} Key;
 
-struct KeyCache
+typedef struct
 {
     size_t cache_bits;
     BIGNUM **cache;
-};
+} KeyCache;
 
-int setup(struct Params *pp, size_t key_len);
-int key_gen(struct Params *pp, struct Key *msk);
+int setup(Params *pp, size_t key_len);
+int key_gen(Params *pp, Key *msk);
 
-void free_master_key(struct Params *pp, struct Key *msk);
-void free_public_params(struct Params *pp);
+void free_master_key(Params *pp, Key *msk);
+void free_public_params(Params *pp);
 
-static inline size_t get_curve_point_byte_size(struct Params *pp)
+static inline size_t get_curve_point_byte_size(Params *pp)
 {
     // get byte size of curve point
     size_t point_len = EC_POINT_point2oct(

--- a/other/src/barebones.c
+++ b/other/src/barebones.c
@@ -2,7 +2,7 @@
 #include "other.h"
 #include "params.h"
 
-int setup(struct Params *pp, size_t key_len)
+int setup(Params *pp, size_t key_len)
 {
     pp->key_len = key_len;
     pp->curve = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
@@ -30,7 +30,7 @@ err:
     return 0;
 }
 
-int key_gen(struct Params *pp, struct Key *msk)
+int key_gen(Params *pp, Key *msk)
 {
     msk->key = malloc(sizeof(void *) * pp->key_len);
     msk->delta = BN_new();
@@ -60,7 +60,7 @@ err:
     return 0;
 }
 
-void free_master_key(struct Params *pp, struct Key *msk)
+void free_master_key(Params *pp, Key *msk)
 {
     for (size_t i = 0; i < pp->key_len; i++)
     {
@@ -75,7 +75,7 @@ void free_master_key(struct Params *pp, struct Key *msk)
     free(msk);
 }
 
-void free_public_params(struct Params *pp)
+void free_public_params(Params *pp)
 {
     if (pp->curve)
         EC_GROUP_free(pp->curve);

--- a/other/src/bench.c
+++ b/other/src/bench.c
@@ -22,13 +22,13 @@ double benchmark_BCMPR_GAR()
 
     size_t key_len = 74; // the size of the predicate chosen in BCMPR
 
-    struct Params *pp = (struct Params *)malloc(sizeof(struct Params));
+    Params *pp = (Params *)malloc(sizeof(Params));
     setup(pp, key_len);
 
     // For benchmarking purposes, we generate two CPRF keys
     // one for each constrained PRF parameterized by set S_b
-    struct Key *msk0 = (struct Key *)malloc(sizeof(struct Key));
-    struct Key *msk1 = (struct Key *)malloc(sizeof(struct Key));
+    Key *msk0 = (Key *)malloc(sizeof(Key));
+    Key *msk1 = (Key *)malloc(sizeof(Key));
     key_gen(pp, msk0);
     key_gen(pp, msk1);
 

--- a/quiet-bipsw/include/bipsw.h
+++ b/quiet-bipsw/include/bipsw.h
@@ -8,7 +8,7 @@
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
-struct Key
+typedef struct
 {
     uint128_t *key_2;
     uint128_t *key_3;
@@ -17,63 +17,63 @@ struct Key
     uint128_t correction_2;
     uint128_t *corrections_3;
     uint8_t *delta;
-};
+} Key;
 
-struct KeyCache
+typedef struct
 {
     uint128_t *cache_2;
     uint128_t *cache_3;
-};
+} KeyCache;
 
-struct PublicParams
+typedef struct
 {
     size_t key_len;
     EVP_CIPHER_CTX *hash_ctx;
     EVP_CIPHER_CTX *prg_ctx;
     PolymurHashParams polymur_params0;
     PolymurHashParams polymur_params1;
-};
+} PublicParams;
 
 void pp_gen(
-    struct PublicParams *pp,
+    PublicParams *pp,
     size_t key_len);
 
-void pp_free(struct PublicParams *pp);
+void pp_free(PublicParams *pp);
 
 void key_gen(
-    struct PublicParams *pp,
-    struct Key *msk);
+    PublicParams *pp,
+    Key *msk);
 
 void constrain_key_gen(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint);
 
 void sender_eval(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct KeyCache *csk_cache,
+    PublicParams *pp,
+    Key *msk,
+    KeyCache *csk_cache,
     const uint16_t *inputs,
     uint128_t *outputs,
     const size_t num_ots);
 
 void receiver_eval(
-    struct PublicParams *pp,
-    struct Key *csk,
-    struct KeyCache *csk_cache,
+    PublicParams *pp,
+    Key *csk,
+    KeyCache *csk_cache,
     const uint16_t *inputs,
     uint128_t *outputs,
     const size_t num_ots);
 
 void compute_key_caches(
-    struct PublicParams *pp,
-    struct Key *key,
-    struct KeyCache *key_cache,
+    PublicParams *pp,
+    Key *key,
+    KeyCache *key_cache,
     size_t mem_size);
 
 void compute_correction_terms(
-    struct Key *msk,
+    Key *msk,
     uint8_t *delta);
 
 #endif

--- a/quiet-bipsw/include/utils.h
+++ b/quiet-bipsw/include/utils.h
@@ -104,7 +104,7 @@ static uint128_t hex_to_uint_128(const char *hex_str)
 }
 
 static inline uint128_t universal_hash_3(
-    struct PublicParams *pp,
+    PublicParams *pp,
     uint128_t *in)
 {
     // Compute a universal hash to compress the input into a uint128

--- a/quiet-bipsw/src/bipsw.c
+++ b/quiet-bipsw/src/bipsw.c
@@ -13,7 +13,7 @@
 #endif
 
 void pp_gen(
-    struct PublicParams *pp,
+    PublicParams *pp,
     size_t key_len)
 {
     pp->key_len = key_len;
@@ -38,7 +38,7 @@ void pp_gen(
     pp->polymur_params0 = p1;
 }
 
-void pp_free(struct PublicParams *pp)
+void pp_free(PublicParams *pp)
 {
     destroy_ctx_key(pp->hash_ctx);
     destroy_ctx_key(pp->prg_ctx);
@@ -52,7 +52,7 @@ void pp_free(struct PublicParams *pp)
 // need to include secret offset k_0 in both msk and csk
 // (k_0 is only required to avoid having a deterministic output on the all-zero
 // input, which has a negligible probability of occurring).
-void key_gen(struct PublicParams *pp, struct Key *msk)
+void key_gen(PublicParams *pp, Key *msk)
 {
     // CPRF master key (in CRT form with mod 2 and mod 3 parts)
     msk->key_2 = malloc(sizeof(uint128_t) * pp->key_len);
@@ -109,9 +109,9 @@ void key_gen(struct PublicParams *pp, struct Key *msk)
 // (k_0 is only required to avoid having a deterministic output on the all-zero
 // input, which has a negligible probability of occurring).
 void constrain_key_gen(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint)
 {
 
@@ -169,9 +169,9 @@ void constrain_key_gen(
 }
 
 static inline void common_eval(
-    struct PublicParams *pp,
-    struct Key *key,
-    struct KeyCache *key_cache,
+    PublicParams *pp,
+    Key *key,
+    KeyCache *key_cache,
     const uint16_t *inputs,
     uint128_t *outputs_2,
     uint128_t *outputs_3,
@@ -322,9 +322,9 @@ static inline void common_eval(
 }
 
 void sender_eval(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct KeyCache *msk_cache,
+    PublicParams *pp,
+    Key *msk,
+    KeyCache *msk_cache,
     const uint16_t *inputs,
     uint128_t *outputs,
     const size_t num_ots)
@@ -390,9 +390,9 @@ void sender_eval(
 }
 
 void receiver_eval(
-    struct PublicParams *pp,
-    struct Key *csk,
-    struct KeyCache *csk_cache,
+    PublicParams *pp,
+    Key *csk,
+    KeyCache *csk_cache,
     const uint16_t *inputs,
     uint128_t *outputs,
     const size_t num_ots)
@@ -431,7 +431,7 @@ void receiver_eval(
 
 // Pre-compute corrections terms
 void compute_correction_terms(
-    struct Key *msk,
+    Key *msk,
     uint8_t *delta)
 {
     msk->corrections_3 = malloc(sizeof(uint128_t) * 6 * 2);

--- a/quiet-bipsw/src/preproc.c
+++ b/quiet-bipsw/src/preproc.c
@@ -6,9 +6,9 @@
 
 // Pre-computes inner products and coefficients used in CPRF evaluation.
 void compute_key_caches(
-    struct PublicParams *pp,
-    struct Key *key,
-    struct KeyCache *key_cache,
+    PublicParams *pp,
+    Key *key,
+    KeyCache *key_cache,
     size_t mem_size)
 {
 

--- a/quiet-bipsw/src/test.c
+++ b/quiet-bipsw/src/test.c
@@ -33,13 +33,13 @@ double benchmarkOTs()
     // **********************************
     // Generate public parameters
     // **********************************
-    struct PublicParams *pp = malloc(sizeof(struct PublicParams));
+    PublicParams *pp = malloc(sizeof(PublicParams));
     pp_gen(pp, key_len);
 
     // **********************************
     // Generate CPRF master key
     // **********************************
-    struct Key *msk = malloc(sizeof(struct Key));
+    Key *msk = malloc(sizeof(Key));
     key_gen(pp, msk);
 
     // **********************************
@@ -47,7 +47,7 @@ double benchmarkOTs()
     // (pre-computed values for inner products)
     // **********************************
     size_t mem_size = (1UL << CACHE_BITS) * (key_len / CACHE_BITS) * sizeof(uint128_t);
-    struct KeyCache *msk_cache = malloc(sizeof(struct KeyCache));
+    KeyCache *msk_cache = malloc(sizeof(KeyCache));
     compute_key_caches(pp, msk, msk_cache, mem_size);
 
     // **********************************
@@ -59,10 +59,10 @@ double benchmarkOTs()
     sample_mod_6(constraint, RING_DIM);
 
     // Compute the constrained key
-    struct Key *csk = malloc(sizeof(struct Key));
+    Key *csk = malloc(sizeof(Key));
     constrain_key_gen(pp, msk, csk, constraint);
 
-    struct KeyCache *csk_cache = malloc(sizeof(struct KeyCache));
+    KeyCache *csk_cache = malloc(sizeof(KeyCache));
     compute_key_caches(pp, csk, csk_cache, mem_size);
 
     // **********************************

--- a/quiet-gar/include/gar.h
+++ b/quiet-gar/include/gar.h
@@ -8,7 +8,7 @@
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
-struct Key
+typedef struct
 {
     uint128_t *key_xor;
     uint8_t *key_maj;
@@ -17,45 +17,45 @@ struct Key
     uint8_t *maj_corrections;
     uint128_t xor_delta;
     uint8_t *maj_delta;
-};
+} Key;
 
-struct PublicParams
+typedef struct
 {
     size_t key_len;
     EVP_CIPHER_CTX *hash_ctx;
     EVP_CIPHER_CTX *prg_ctx;
     PolymurHashParams polymur_params0;
     PolymurHashParams polymur_params1;
-};
+} PublicParams;
 
-void pp_gen(struct PublicParams *pp);
-void pp_free(struct PublicParams *pp);
+void pp_gen(PublicParams *pp);
+void pp_free(PublicParams *pp);
 
-void key_gen(struct PublicParams *pp, struct Key *msk);
+void key_gen(PublicParams *pp, Key *msk);
 
 void constrain_key_gen(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint);
 
 void GenerateRandomInputs(
-    struct PublicParams *pp,
+    PublicParams *pp,
     uint16_t *xor_inputs,
     uint16_t *maj_inputs,
     size_t num_ots);
 
 void sender_eval(
-    struct PublicParams *pp,
-    struct Key *msk,
+    PublicParams *pp,
+    Key *msk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
     uint128_t *outputs,
     const size_t num_ots);
 
 void receiver_eval(
-    struct PublicParams *pp,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *csk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
     uint128_t *outputs,

--- a/quiet-gar/include/utils.h
+++ b/quiet-gar/include/utils.h
@@ -88,7 +88,7 @@ static uint128_t hex_to_uint_128(const char *hex_str)
     return result;
 }
 
-static inline uint128_t universal_hash(struct PublicParams *pp, uint8_t *in, size_t len)
+static inline uint128_t universal_hash(PublicParams *pp, uint8_t *in, size_t len)
 {
     // Compute a universal hash to compress the input into a uint128
     // integer that we then feed into the random oracle.

--- a/quiet-gar/src/gar.c
+++ b/quiet-gar/src/gar.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <openssl/rand.h>
 
-void pp_gen(struct PublicParams *pp)
+void pp_gen(PublicParams *pp)
 {
     // Generate PRG key (for generating random inputs)
     uint128_t prg_key;
@@ -30,14 +30,14 @@ void pp_gen(struct PublicParams *pp)
     pp->polymur_params1 = p1;
 }
 
-void pp_free(struct PublicParams *pp)
+void pp_free(PublicParams *pp)
 {
     destroy_ctx_key(pp->hash_ctx);
     destroy_ctx_key(pp->prg_ctx);
     free(pp);
 }
 
-void key_gen(struct PublicParams *pp, struct Key *msk)
+void key_gen(PublicParams *pp, Key *msk)
 {
     msk->key_xor = malloc(sizeof(uint128_t) * KEY_LEN);
     msk->key_maj = malloc(sizeof(uint8_t) * KEY_LEN * RING_DIM);
@@ -61,9 +61,9 @@ void key_gen(struct PublicParams *pp, struct Key *msk)
 }
 
 void constrain_key_gen(
-    struct PublicParams *pp,
-    struct Key *msk,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *msk,
+    Key *csk,
     uint8_t *constraint)
 {
 
@@ -105,7 +105,7 @@ void compute_correction_terms(
 }
 
 static inline void common_eval(
-    const struct Key *key,
+    const Key *key,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
     uint128_t *xor_outputs,
@@ -163,8 +163,8 @@ static inline void common_eval(
 }
 
 void sender_eval(
-    struct PublicParams *pp,
-    struct Key *msk,
+    PublicParams *pp,
+    Key *msk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
     uint128_t *outputs,
@@ -256,8 +256,8 @@ void sender_eval(
 }
 
 void receiver_eval(
-    struct PublicParams *pp,
-    struct Key *csk,
+    PublicParams *pp,
+    Key *csk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
     uint128_t *outputs,
@@ -305,7 +305,7 @@ void receiver_eval(
 }
 
 void GenerateRandomInputs(
-    struct PublicParams *pp,
+    PublicParams *pp,
     uint16_t *xor_inputs,
     uint16_t *maj_inputs,
     size_t num_ots)

--- a/quiet-gar/src/test.c
+++ b/quiet-gar/src/test.c
@@ -16,13 +16,13 @@ double benchmarkOTs()
     // **********************************
     // Generate public parameters
     // **********************************
-    struct PublicParams *pp = malloc(sizeof(struct PublicParams));
+    PublicParams *pp = malloc(sizeof(PublicParams));
     pp_gen(pp);
 
     // **********************************
     // Generate CPRF master key
     // **********************************
-    struct Key *msk = malloc(sizeof(struct Key));
+    Key *msk = malloc(sizeof(Key));
     key_gen(pp, msk);
 
     uint8_t *constraint = malloc(sizeof(uint8_t) * KEY_LEN);
@@ -31,7 +31,7 @@ double benchmarkOTs()
         constraint[i] &= 1;
 
     // Compute the constrained key
-    struct Key *csk = malloc(sizeof(struct Key));
+    Key *csk = malloc(sizeof(Key));
     constrain_key_gen(pp, msk, csk, constraint);
 
     clock_t t = clock();


### PR DESCRIPTION
Uses typedef for structs to visually simplify the code. 