### PR TITLE
Universal hashing with more entropy + other TODOs

### DIFF
--- a/bcmpr-bipsw/src/bcmpr.c
+++ b/bcmpr-bipsw/src/bcmpr.c
@@ -62,8 +62,6 @@ int key_gen(Params *pp, Key *msk)
     if (!BN_rand_range(msk->delta, pp->order))
         goto err;
 
-    BN_set_word(msk->delta, 2); // TODO: remove
-
     // sample Delta and offsets
     BIGNUM *delta_pow = BN_new();
     BN_set_word(delta_pow, 1);

--- a/quiet-bipsw/include/utils.h
+++ b/quiet-bipsw/include/utils.h
@@ -103,20 +103,4 @@ static uint128_t hex_to_uint_128(const char *hex_str)
     return result;
 }
 
-static inline uint128_t universal_hash_3(
-    PublicParams *pp,
-    uint128_t *in)
-{
-    // Compute a universal hash to compress the input into a uint128
-    // integer that we then feed into the random oracle.
-    // Because polymur_hash outputs a uint64, we hash twice with
-    // different keys and concatenate the results
-    uint128_t out = polymur_hash(
-        (uint8_t *)in, 3 * 16, &pp->polymur_params0, POLYMUR_TWEAK);
-    out = out << 64;
-    out |= polymur_hash(
-        (uint8_t *)in, 3 * 16, &pp->polymur_params1, POLYMUR_TWEAK);
-    return out;
-}
-
 #endif

--- a/quiet-bipsw/src/bipsw.c
+++ b/quiet-bipsw/src/bipsw.c
@@ -3,7 +3,6 @@
 #include "bipsw.h"
 #include "utils.h"
 #include "params.h"
-#include "polymur.h"
 
 #include <stdlib.h>
 #include <openssl/rand.h>
@@ -347,24 +346,24 @@ void sender_eval(
     uint128_t *output;
     uint128_t *output_2;
     uint128_t *output_3;
-    uint128_t uhash_in[3];
 
-    uint128_t *hash_in = malloc(sizeof(uint128_t) * num_ots * 6);
+    uint128_t *hash_in = malloc(sizeof(uint128_t) * num_ots * 6 * 3);
+    uint128_t *hash_out = malloc(sizeof(uint128_t) * num_ots * 6 * 3);
 
     size_t output_offset = 0;
     for (size_t n = 0; n < num_ots; n++)
     {
-        output = &hash_in[n * 6];
+        output = &hash_in[n * 6 * 3];
         output_2 = &outputs_2[n];
         output_3 = &outputs_3[2 * n];
 
         // subtract the correction terms
         for (size_t i = 0; i < 6; i++)
         {
-            uhash_in[0] = output_2[0] ^ (msk->correction_2 * (i % 2));
+            output[3 * i] = output_2[0] ^ (msk->correction_2 * (i % 2));
 
-            uhash_in[1] = output_3[0];
-            uhash_in[2] = output_3[1];
+            output[3 * i + 1] = output_3[0];
+            output[3 * i + 2] = output_3[1];
 
             // TODO [BUG]: fix this weirdness.
             // Basically there is some issue with the way the corrections are
@@ -372,21 +371,23 @@ void sender_eval(
             // swapped in this way. Removing these if statements will improve
             // efficiency but currently this is a workaround.
             if (i == 0)
-                inplace_mod_3_subr(&uhash_in[1], &msk->corrections_3[0]);
+                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[0]);
             else if (i == 1 || i == 4)
-                inplace_mod_3_subr(&uhash_in[1], &msk->corrections_3[4]);
+                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[4]);
             else if (i == 2 || i == 5)
-                inplace_mod_3_subr(&uhash_in[1], &msk->corrections_3[2]);
-
-            output[i] = universal_hash_3(pp, &uhash_in[0]);
+                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[2]);
         }
     }
 
-    prf_batch_eval(pp->hash_ctx, &hash_in[0], &outputs[0], num_ots * 6);
+    prf_batch_eval(pp->hash_ctx, &hash_in[0], &hash_out[0], num_ots * 6 * 3);
+
+    for (size_t n = 0; n < num_ots * 6; n++)
+        outputs[n] = hash_out[3 * n] ^ hash_out[3 * n + 1] ^ hash_out[3 * n + 2];
 
     free(outputs_2);
     free(outputs_3);
     free(hash_in);
+    free(hash_out);
 }
 
 void receiver_eval(
@@ -411,22 +412,25 @@ void receiver_eval(
         outputs_3,
         num_ots);
 
-    uint128_t *hash_in = malloc(sizeof(uint128_t) * num_ots);
-    uint128_t uhash_in[3];
+    uint128_t *hash_in = malloc(sizeof(uint128_t) * num_ots * 3);
+    uint128_t *hash_out = malloc(sizeof(uint128_t) * num_ots * 3);
+
     for (size_t n = 0; n < num_ots; n++)
     {
-        uhash_in[0] = outputs_2[n];
-        uhash_in[1] = outputs_3[2 * n];
-        uhash_in[2] = outputs_3[2 * n + 1];
-
-        hash_in[n] = universal_hash_3(pp, &uhash_in[0]);
+        hash_in[3 * n] = outputs_2[n];
+        hash_in[3 * n + 1] = outputs_3[2 * n];
+        hash_in[3 * n + 2] = outputs_3[2 * n + 1];
     }
 
-    prf_batch_eval(pp->hash_ctx, &hash_in[0], &outputs[0], num_ots);
+    prf_batch_eval(pp->hash_ctx, &hash_in[0], &hash_out[0], num_ots * 3);
+
+    for (size_t n = 0; n < num_ots; n++)
+        outputs[n] = hash_out[3 * n] ^ hash_out[3 * n + 1] ^ hash_out[3 * n + 2];
 
     free(outputs_2);
     free(outputs_3);
     free(hash_in);
+    free(hash_out);
 }
 
 // Pre-compute corrections terms

--- a/quiet-bipsw/src/bipsw.c
+++ b/quiet-bipsw/src/bipsw.c
@@ -365,17 +365,7 @@ void sender_eval(
             output[3 * i + 1] = output_3[0];
             output[3 * i + 2] = output_3[1];
 
-            // TODO [BUG]: fix this weirdness.
-            // Basically there is some issue with the way the corrections are
-            // computed for the Z3 case. It's unclear why the indexing is
-            // swapped in this way. Removing these if statements will improve
-            // efficiency but currently this is a workaround.
-            if (i == 0)
-                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[0]);
-            else if (i == 1 || i == 4)
-                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[4]);
-            else if (i == 2 || i == 5)
-                inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[2]);
+            inplace_mod_3_subr(&output[3 * i + 1], &msk->corrections_3[2 * i]);
         }
     }
 
@@ -458,6 +448,7 @@ void compute_correction_terms(
         {
             msk->corrections_3[2 * i] = 0;
             msk->corrections_3[2 * i + 1] = 0;
+            continue;
         }
 
         packed_3[0] = 0;
@@ -467,7 +458,7 @@ void compute_correction_terms(
         for (size_t j = 0; j < RING_DIM; j++)
         {
 
-            prod = ((i * delta[j]) % 6) % 3;
+            prod = 3 - ((i * delta[j]) % 6) % 3; // need to negate (mod 3)
 
             if (prod == 2)
             {

--- a/quiet-gar/include/gar.h
+++ b/quiet-gar/include/gar.h
@@ -10,12 +10,14 @@ typedef unsigned __int128 uint128_t;
 
 typedef struct
 {
-    uint128_t *key_xor;
+    uint128_t *key_xor_128;
+    uint64_t *key_xor_64;
     uint8_t *key_maj;
 
     // optional fields (only present for MSK)
     uint8_t *maj_corrections;
-    uint128_t xor_delta;
+    uint128_t xor_delta_128;
+    uint64_t xor_delta_64;
     uint8_t *maj_delta;
 } Key;
 

--- a/quiet-gar/include/params.h
+++ b/quiet-gar/include/params.h
@@ -15,7 +15,7 @@
 // #define XOR_LEN 7
 // #define MAJ_LEN 31
 
-#define RING_DIM 128
+#define RING_DIM (128 + 64)
 #define NUM_COMBOS (2 * (MAJ_LEN + 1))
 
 #define RAND_BUFFER 4

--- a/quiet-gar/include/utils.h
+++ b/quiet-gar/include/utils.h
@@ -43,13 +43,9 @@ static inline int sample_random_distinct_key_indices(
     j = 0;
     while (i < num)
     {
-        // TODO[optimization]: skip this bias check?
-        // very low probability of happening p=(2^16 - 65160)/2^16 ~ 0.6%
-        // if (randomness[j] < BIAS_CONDITION_FOR_KEY_SAMPLING)
-        // rand_indices[i++] = randomness[j] & KEY_LEN;
-
+        // WARNING: assumes that KEY_LEN is a power of 2;
+        // otherwise need to perform rejection sampling
         rand_indices[i++] = randomness[j] & (KEY_LEN - 1); // if power of 2
-
         j++;
     }
 


### PR DESCRIPTION
Bumps the ring size of the GAR construction to ensure sufficient entropy when extracting randomness from the ring elements. Previously the total entropy of the ring element was 128 bits, now we make it 128+64 to allow for randomness extraction with good theoretical guarantees on the uniformity of the output keys using the results of Barak et al. that generalize LHL to computational settings. For BIPSW, the universal hash is instead replaced with AES, this doesn't noticeably impact performance for the BIPSW implementation since it only adds two extra AES calls and avoids the need to use universal hashing altogether.  

Along the way, some lingering TODOs were fixed.  