### PR TITLE
Optimizations

### DIFF
--- a/pr/prf.h
+++ b/pr/prf.h
@@ -56,4 +56,10 @@ static inline void prf_batch_eval(EVP_CIPHER_CTX *ctx, uint128_t *input, uint128
     //     printf("errors ocurred in PRF evaluation\n");
 }
 
+static inline void aes_batch_eval(EVP_CIPHER_CTX *ctx, uint128_t *input, uint128_t *outputs, int num_blocks)
+{
+    static int len = 0; // make static to avoid reallocating
+    EVP_EncryptUpdate(ctx, (uint8_t *)outputs, &len, (uint8_t *)input, 16 * num_blocks);
+}
+
 #endif

--- a/quiet-bipsw/include/bipsw.h
+++ b/quiet-bipsw/include/bipsw.h
@@ -54,7 +54,7 @@ void sender_eval(
     Key *msk,
     KeyCache *csk_cache,
     const uint16_t *inputs,
-    uint64_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots);
 
 void receiver_eval(
@@ -62,7 +62,7 @@ void receiver_eval(
     Key *csk,
     KeyCache *csk_cache,
     const uint16_t *inputs,
-    uint64_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots);
 
 void compute_key_caches(

--- a/quiet-bipsw/include/bipsw.h
+++ b/quiet-bipsw/include/bipsw.h
@@ -30,7 +30,6 @@ typedef struct
     size_t key_len;
     EVP_CIPHER_CTX *hash_ctx;
     EVP_CIPHER_CTX *prg_ctx;
-    PolymurHashParams polymur_params;
 } PublicParams;
 
 void pp_gen(

--- a/quiet-bipsw/include/params.h
+++ b/quiet-bipsw/include/params.h
@@ -6,6 +6,7 @@
 #define RING_DIM 128  // has to be <= 128
 #define KEY_LEN 768   // needs to be divisible by CACHE_BITS
 #define CACHE_BITS 16 // how many consecutive bits of the input should be cached
+// TODO: remove dependency on CACHE_BITS = 16
 
 #define POLYMUR_SEED0 0x28ce40f3881d9798ULL
 #define POLYMUR_SEED1 0x67ee64638656503eULL

--- a/quiet-bipsw/include/utils.h
+++ b/quiet-bipsw/include/utils.h
@@ -6,7 +6,6 @@
 #include <openssl/rand.h>
 
 #include "params.h"
-#include "polymur.h"
 
 static inline void sample_mod_6(uint8_t *outputs, size_t num)
 {
@@ -102,16 +101,6 @@ static uint128_t hex_to_uint_128(const char *hex_str)
     }
 
     return result;
-}
-
-static inline uint32_t universal_hash_3(
-    PublicParams *pp,
-    uint128_t *in)
-{
-    // Compute a universal hash to compress the input into a uint64
-    uint64_t out = polymur_hash(
-        (uint8_t *)in, 3 * 16, &pp->polymur_params, POLYMUR_TWEAK);
-    return out;
 }
 
 #endif

--- a/quiet-bipsw/src/bipsw.c
+++ b/quiet-bipsw/src/bipsw.c
@@ -323,7 +323,7 @@ void sender_eval(
     Key *msk,
     KeyCache *msk_cache,
     const uint16_t *inputs,
-    uint64_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots)
 {
 
@@ -369,8 +369,9 @@ void sender_eval(
 
     prf_batch_eval(pp->hash_ctx, &hash_in[0], &hash_out[0], num_ots * 6 * 3);
 
+    // apply universal hash to the output blocks and truncate it to one bit
     for (size_t n = 0; n < num_ots * 6; n++)
-        outputs[n] = universal_hash_3(pp, &hash_out[3 * n]);
+        outputs[n] = universal_hash_3(pp, &hash_out[3 * n]) & 1;
 
     free(outputs_2);
     free(outputs_3);
@@ -383,7 +384,7 @@ void receiver_eval(
     Key *csk,
     KeyCache *csk_cache,
     const uint16_t *inputs,
-    uint64_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots)
 {
     uint128_t *outputs_2;
@@ -412,8 +413,9 @@ void receiver_eval(
 
     prf_batch_eval(pp->hash_ctx, &hash_in[0], &hash_out[0], num_ots * 3);
 
+    // apply universal hash to the output blocks and truncate it to one bit
     for (size_t n = 0; n < num_ots; n++)
-        outputs[n] = universal_hash_3(pp, &hash_out[3 * n]);
+        outputs[n] = universal_hash_3(pp, &hash_out[3 * n]) & 1;
 
     free(outputs_2);
     free(outputs_3);

--- a/quiet-bipsw/src/test.c
+++ b/quiet-bipsw/src/test.c
@@ -69,10 +69,10 @@ double benchmarkOTs()
     // Benchmarks and tests
     // **********************************
     uint16_t *inputs = (uint16_t *)malloc(sizeof(uint16_t) * (KEY_LEN / CACHE_BITS) * num_inputs);
-    uint64_t *outputs_sender;
-    uint64_t *outputs_receiver;
-    posix_memalign((void **)&outputs_sender, 64, num_outputs * 6 * sizeof(uint64_t));
-    posix_memalign((void **)&outputs_receiver, 64, num_outputs * sizeof(uint64_t));
+    uint8_t *outputs_sender;
+    uint8_t *outputs_receiver;
+    posix_memalign((void **)&outputs_sender, 64, num_outputs * 6 * sizeof(uint8_t));
+    posix_memalign((void **)&outputs_receiver, 64, num_outputs * sizeof(uint8_t));
 
     clock_t t = clock();
 

--- a/quiet-gar/include/gar.h
+++ b/quiet-gar/include/gar.h
@@ -24,7 +24,8 @@ typedef struct
 typedef struct
 {
     size_t key_len;
-    EVP_CIPHER_CTX *hash_ctx;
+    EVP_CIPHER_CTX *hash_ctx0;
+    EVP_CIPHER_CTX *hash_ctx1;
     EVP_CIPHER_CTX *prg_ctx;
     PolymurHashParams polymur_params0;
     PolymurHashParams polymur_params1;
@@ -52,7 +53,7 @@ void sender_eval(
     Key *msk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
-    uint128_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots);
 
 void receiver_eval(
@@ -60,7 +61,7 @@ void receiver_eval(
     Key *csk,
     const uint16_t *xor_inputs,
     const uint16_t *maj_inputs,
-    uint128_t *outputs,
+    uint8_t *outputs,
     const size_t num_ots);
 
 void compute_correction_terms(

--- a/quiet-gar/include/params.h
+++ b/quiet-gar/include/params.h
@@ -7,11 +7,13 @@
 
 // PARAMETER SET #1: (Stretch=2^36; Security=2^232)
 #define KEY_LEN 2048
+#define LOG_KEY_LEN 11
 #define XOR_LEN 5
 #define MAJ_LEN 15
 
 // PARAMETER SET #2: (Stretch=2^36; Security=2^147)
 // #define KEY_LEN 512
+// #define LOG_KEY_LEN 9
 // #define XOR_LEN 7
 // #define MAJ_LEN 31
 

--- a/quiet-gar/include/params.h
+++ b/quiet-gar/include/params.h
@@ -7,13 +7,11 @@
 
 // PARAMETER SET #1: (Stretch=2^36; Security=2^232)
 #define KEY_LEN 2048
-#define LOG_KEY_LEN 11
 #define XOR_LEN 5
 #define MAJ_LEN 15
 
 // PARAMETER SET #2: (Stretch=2^36; Security=2^147)
 // #define KEY_LEN 512
-// #define LOG_KEY_LEN 9
 // #define XOR_LEN 7
 // #define MAJ_LEN 31
 

--- a/quiet-gar/src/test.c
+++ b/quiet-gar/src/test.c
@@ -40,8 +40,8 @@ double benchmarkOTs()
     uint16_t *maj_inputs = malloc(sizeof(uint16_t) * MAJ_LEN * num_ots);
     GenerateRandomInputs(pp, xor_inputs, maj_inputs, num_ots);
 
-    uint128_t *outputs_sender = malloc(sizeof(uint128_t) * num_ots * NUM_COMBOS);
-    uint128_t *outputs_receiver = malloc(sizeof(uint128_t) * num_ots);
+    uint8_t *outputs_sender = malloc(sizeof(uint8_t) * num_ots * NUM_COMBOS);
+    uint8_t *outputs_receiver = malloc(sizeof(uint8_t) * num_ots);
 
     sender_eval(pp,
                 msk,


### PR DESCRIPTION
- Make the outputs of PCFs bits rather than strings
- Don't xor the input with the output of AES since we're truncating to bits anyway (see https://eprint.iacr.org/2019/074.pdf)
- Incorporate the input strings into the hashing to better match the construction in the paper 
- Faster BIPSW instantiation by just xor'ing the output blocks (then truncating)  rather than universal hashing the output 