### PR TITLE
Fix broken AVX variant 

### DIFF
--- a/quiet-bipsw/Makefile
+++ b/quiet-bipsw/Makefile
@@ -4,8 +4,8 @@ CFLAGS = -O3 -I./include -I../pr -I/opt/homebrew/opt/openssl/include
 LDFLAGS = -march=native -lcrypto -lssl -lm -maes -ffast-math
 
 ifeq ($(AVX),1)
-    CFLAGS += -DAVX
-    LDFLAGS += -mavx512f
+ CFLAGS += -DAVX -mavx512f
+ LDFLAGS += -mavx512f
 endif
 
 SRC = $(wildcard ./src/*.c)

--- a/quiet-bipsw/include/bipsw.h
+++ b/quiet-bipsw/include/bipsw.h
@@ -5,6 +5,10 @@
 #include <openssl/evp.h>
 #include "polymur.h"
 
+#ifdef AVX
+#include <immintrin.h>
+#endif
+
 typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
@@ -23,6 +27,11 @@ typedef struct
 {
     uint128_t *cache_2;
     uint128_t *cache_3;
+#ifdef AVX
+    __m512i *cache_2_avx;
+    __m512i *cache_3_avx;
+#endif
+
 } KeyCache;
 
 typedef struct

--- a/quiet-bipsw/src/bipsw.c
+++ b/quiet-bipsw/src/bipsw.c
@@ -177,8 +177,6 @@ static inline void common_eval(
 
 #ifdef AVX
     size_t mem_size = num_blocks * cache_block_size * sizeof(__m512i);
-    __m512i * key_cache->cache_2_avx;
-    __m512i * key_cache->cache_3_avx;
 
     // allocate aligned memory for AVX512
     posix_memalign((void **)&key_cache->cache_2_avx, 64, mem_size);

--- a/quiet-bipsw/src/test.c
+++ b/quiet-bipsw/src/test.c
@@ -143,7 +143,7 @@ double benchmarkOTs()
         }
     }
 
-    printf("Index dist: (%i, %i, %i, %i, %i, %i)\n", dist[0], dist[1], dist[2], dist[3], dist[4], dist[5]);
+    // printf("Index dist: (%i, %i, %i, %i, %i, %i)\n", dist[0], dist[1], dist[2], dist[3], dist[4], dist[5]);
 
     if (not_found != 0)
     {


### PR DESCRIPTION
AVX version of quiet-bipsw was broken following changes to the code base 